### PR TITLE
Issue 10 sieze blacklisted funds

### DIFF
--- a/src/interfaces/IUSDat.sol
+++ b/src/interfaces/IUSDat.sol
@@ -5,4 +5,6 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface IUSDat is IERC20 {
     function mint(address to, uint256 amount) external;
+
+    function isBlacklisted(address account) external view returns (bool);
 }


### PR DESCRIPTION
https://github.com/saturn-organization/saturn-yield-dollar/issues/10

Create function `seizeBlacklistedFunds` to sieze blacklisted funds from users in the queue after the request has been processed. The PR current siezes funds the same way a user would claim funds. It does not address [issue 17](https://github.com/saturn-organization/saturn-yield-dollar/issues/17). This will happen in a separate PR. 