### PR TITLE
Issue 20: Add support for slippage tolerant deposit 

### DIFF
--- a/src/interfaces/IWithdrawalQueueERC721.sol
+++ b/src/interfaces/IWithdrawalQueueERC721.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 interface IWithdrawalQueueERC721 {
-    function addRequest(address owner, uint256 strcAmount) external;
+    function addRequest(address owner, uint256 strcAmount, uint256 minStrcPrice) external;
 
     function claimFor(address user) external returns (uint256 totalAmount);
 


### PR DESCRIPTION
https://github.com/saturn-organization/saturn-yield-dollar/issues/20

1. Adding support for slippage tolerant deposit with `depositWithMinShares/mintWithMaxAssets`
2. When a user submits a withdrawal request, they specify an `minStrcPrice` that they are comfortable leaving the queue for