### PR TITLE
Fix pausing on sUSDat and WithdrawalQueue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,7 @@ out/
 docs/
 
 # Dotenv file
-.env
+.env.*
+
+*.csr
+*.key

--- a/src/StakedUSDat.sol
+++ b/src/StakedUSDat.sol
@@ -186,12 +186,7 @@ contract StakedUSDat is
     }
 
     /// @inheritdoc IERC20
-    function transfer(address to, uint256 amount)
-        public
-        override(ERC20Upgradeable, IERC20)
-        whenNotPaused
-        returns (bool)
-    {
+    function transfer(address to, uint256 amount) public override(ERC20Upgradeable, IERC20) returns (bool) {
         _requireNotBlacklisted(msg.sender);
         _requireNotBlacklisted(to);
         return super.transfer(to, amount);
@@ -201,7 +196,6 @@ contract StakedUSDat is
     function transferFrom(address from, address to, uint256 amount)
         public
         override(ERC20Upgradeable, IERC20)
-        whenNotPaused
         returns (bool)
     {
         _requireNotBlacklisted(from);
@@ -217,7 +211,11 @@ contract StakedUSDat is
         require(amountToDistribute > 0, ZeroAmount());
         require(totalSupply() > amountToDistribute, NoRecipientsForRedistribution());
 
+        bool wasPaused = paused();
+        if (wasPaused) _unpause();
         _burn(from, amountToDistribute);
+        if (wasPaused) _pause();
+
         emit LockedAmountRedistributed(from, amountToDistribute);
     }
 
@@ -339,6 +337,7 @@ contract StakedUSDat is
     /// @inheritdoc IStakedUSDat
     function convertFromUsdat(uint256 usdatAmount, uint256 strcAmount, uint256 strcPurchasePrice)
         external
+        whenNotPaused
         onlyRole(PROCESSOR_ROLE)
     {
         require(usdatBalance >= usdatAmount, InsufficientBalance());
@@ -356,6 +355,7 @@ contract StakedUSDat is
     /// @inheritdoc IStakedUSDat
     function convertFromStrc(uint256 strcAmount, uint256 usdatAmount, uint256 strcSalePrice)
         external
+        whenNotPaused
         onlyRole(PROCESSOR_ROLE)
     {
         uint256 unvestedAmount = getUnvestedAmount();
@@ -397,7 +397,6 @@ contract StakedUSDat is
     function _deposit(address caller, address receiver, uint256 assets, uint256 shares)
         internal
         override
-        whenNotPaused
         nonReentrant
         notZero(assets)
         notZero(shares)
@@ -518,11 +517,7 @@ contract StakedUSDat is
     // ============ Withdrawal Functions ============
 
     /// @inheritdoc IStakedUSDat
-    function requestRedeem(uint256 shares, uint256 minUsdatReceived)
-        external
-        whenNotPaused
-        returns (uint256 requestId)
-    {
+    function requestRedeem(uint256 shares, uint256 minUsdatReceived) external returns (uint256 requestId) {
         uint256 maxShares = maxRedeem(msg.sender);
         if (shares > maxShares) {
             revert ERC4626ExceededMaxRedeem(msg.sender, shares, maxShares);
@@ -641,5 +636,14 @@ contract StakedUSDat is
     /// @inheritdoc IStakedUSDat
     function unpause() external onlyRole(DEFAULT_ADMIN_ROLE) {
         _unpause();
+    }
+
+    /// @dev Blocks all token movements when paused, except burns from blacklisted addresses by DEFAULT_ADMIN_ROLE.
+    function _update(address from, address to, uint256 value)
+        internal
+        override(ERC20Upgradeable, ERC4626Upgradeable)
+        whenNotPaused
+    {
+        super._update(from, to, value);
     }
 }

--- a/src/StakedUSDat.sol
+++ b/src/StakedUSDat.sol
@@ -584,7 +584,7 @@ contract StakedUSDat is
     // ============ Admin Functions ============
 
     /// @inheritdoc IStakedUSDat
-    function setVestingPeriod(uint256 newVestingPeriod) external onlyRole(PROCESSOR_ROLE) {
+    function setVestingPeriod(uint256 newVestingPeriod) external onlyRole(DEFAULT_ADMIN_ROLE) {
         require(newVestingPeriod > 0 && newVestingPeriod <= MAX_VESTING_PERIOD, InvalidVestingPeriod());
         require(getUnvestedAmount() == 0, StillVesting());
 
@@ -595,7 +595,7 @@ contract StakedUSDat is
     }
 
     /// @inheritdoc IStakedUSDat
-    function setDepositFee(uint256 newFeeBps) external onlyRole(PROCESSOR_ROLE) {
+    function setDepositFee(uint256 newFeeBps) external onlyRole(DEFAULT_ADMIN_ROLE) {
         require(newFeeBps <= MAX_DEPOSIT_FEE_BPS, InvalidFee());
 
         depositFeeBps = newFeeBps;
@@ -604,7 +604,7 @@ contract StakedUSDat is
     }
 
     /// @inheritdoc IStakedUSDat
-    function setFeeRecipient(address newRecipient) external onlyRole(PROCESSOR_ROLE) {
+    function setFeeRecipient(address newRecipient) external onlyRole(DEFAULT_ADMIN_ROLE) {
         feeRecipient = newRecipient;
 
         emit FeeRecipientUpdated(newRecipient);

--- a/src/StakedUSDat.sol
+++ b/src/StakedUSDat.sol
@@ -186,7 +186,12 @@ contract StakedUSDat is
     }
 
     /// @inheritdoc IERC20
-    function transfer(address to, uint256 amount) public override(ERC20Upgradeable, IERC20) returns (bool) {
+    function transfer(address to, uint256 amount)
+        public
+        override(ERC20Upgradeable, IERC20)
+        whenNotPaused
+        returns (bool)
+    {
         _requireNotBlacklisted(msg.sender);
         _requireNotBlacklisted(to);
         return super.transfer(to, amount);
@@ -196,6 +201,7 @@ contract StakedUSDat is
     function transferFrom(address from, address to, uint256 amount)
         public
         override(ERC20Upgradeable, IERC20)
+        whenNotPaused
         returns (bool)
     {
         _requireNotBlacklisted(from);

--- a/src/StakedUSDat.sol
+++ b/src/StakedUSDat.sol
@@ -639,11 +639,7 @@ contract StakedUSDat is
     }
 
     /// @dev Blocks all token movements when paused, except burns from blacklisted addresses by DEFAULT_ADMIN_ROLE.
-    function _update(address from, address to, uint256 value)
-        internal
-        override(ERC20Upgradeable, ERC4626Upgradeable)
-        whenNotPaused
-    {
+    function _update(address from, address to, uint256 value) internal override(ERC20Upgradeable) whenNotPaused {
         super._update(from, to, value);
     }
 }

--- a/src/WithdrawalQueueERC721.sol
+++ b/src/WithdrawalQueueERC721.sol
@@ -158,7 +158,7 @@ contract WithdrawalQueueERC721 is
     // ============ Processing Functions ============
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function lockRequests(uint256[] calldata tokenIds) external onlyRole(PROCESSOR_ROLE) {
+    function lockRequests(uint256[] calldata tokenIds) external whenNotPaused onlyRole(PROCESSOR_ROLE) {
         uint256 count = tokenIds.length;
         require(count > 0, InvalidInputs());
 
@@ -172,7 +172,7 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function unlockRequests(uint256[] calldata tokenIds) external onlyRole(PROCESSOR_ROLE) {
+    function unlockRequests(uint256[] calldata tokenIds) external whenNotPaused onlyRole(PROCESSOR_ROLE) {
         uint256 count = tokenIds.length;
         require(count > 0, InvalidInputs());
 
@@ -227,7 +227,7 @@ contract WithdrawalQueueERC721 is
         uint256 totalUsdatReceived,
         uint256 totalStrcSold,
         uint256 executionPrice
-    ) external nonReentrant onlyRole(PROCESSOR_ROLE) {
+    ) external nonReentrant whenNotPaused onlyRole(PROCESSOR_ROLE) {
         uint256 count = tokenIds.length;
         require(count > 0, InvalidInputs());
 
@@ -270,7 +270,7 @@ contract WithdrawalQueueERC721 is
     // ============ Claiming Functions ============
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function claim(uint256 tokenId) external nonReentrant whenNotPaused returns (uint256 amount) {
+    function claim(uint256 tokenId) external nonReentrant returns (uint256 amount) {
         _requireNotBlacklisted(msg.sender);
         require(ownerOf(tokenId) == msg.sender, NotOwner());
 
@@ -288,7 +288,7 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function claimBatch(uint256[] calldata tokenIds) external nonReentrant whenNotPaused returns (uint256 totalAmount) {
+    function claimBatch(uint256[] calldata tokenIds) external nonReentrant returns (uint256 totalAmount) {
         _requireNotBlacklisted(msg.sender);
         uint256 len = tokenIds.length;
         require(len > 0, ZeroAmount());
@@ -315,7 +315,6 @@ contract WithdrawalQueueERC721 is
     function claimBatchFor(address user, uint256[] calldata tokenIds)
         external
         nonReentrant
-        whenNotPaused
         onlyRole(STAKED_USDAT_ROLE)
         returns (uint256 totalAmount)
     {
@@ -342,19 +341,13 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function claimAll() external nonReentrant whenNotPaused returns (uint256 totalAmount) {
+    function claimAll() external nonReentrant returns (uint256 totalAmount) {
         _requireNotBlacklisted(msg.sender);
         totalAmount = _claimAllFor(msg.sender);
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function claimAllFor(address user)
-        external
-        nonReentrant
-        whenNotPaused
-        onlyRole(STAKED_USDAT_ROLE)
-        returns (uint256 totalAmount)
-    {
+    function claimAllFor(address user) external nonReentrant onlyRole(STAKED_USDAT_ROLE) returns (uint256 totalAmount) {
         _requireNotBlacklisted(user);
         totalAmount = _claimAllFor(user);
     }
@@ -511,6 +504,9 @@ contract WithdrawalQueueERC721 is
         uint256 len = tokenIds.length;
         require(len > 0, ZeroAmount());
 
+        bool wasPaused = paused();
+        if (wasPaused) _unpause();
+
         for (uint256 i = 0; i < len; i++) {
             uint256 tokenId = tokenIds[i];
             address owner = ownerOf(tokenId);
@@ -523,6 +519,8 @@ contract WithdrawalQueueERC721 is
 
             emit RequestSeized(tokenId, owner, to);
         }
+
+        if (wasPaused) _pause();
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
@@ -534,6 +532,9 @@ contract WithdrawalQueueERC721 is
         require(to != address(0), ZeroAmount());
         uint256 len = tokenIds.length;
         require(len > 0, ZeroAmount());
+
+        bool wasPaused = paused();
+        if (wasPaused) _unpause();
 
         uint256 totalUsdatSeized = 0;
 
@@ -553,6 +554,8 @@ contract WithdrawalQueueERC721 is
             emit FundsSeized(tokenId, owner, req.usdatOwed, to);
         }
 
+        if (wasPaused) _pause();
+
         IERC20(address(USDAT)).safeTransfer(to, totalUsdatSeized);
     }
 
@@ -568,8 +571,8 @@ contract WithdrawalQueueERC721 is
 
     // ============ Required Overrides ============
 
-    /// @dev Override to check blacklist on transfers.
-    function _update(address to, uint256 tokenId, address auth) internal override returns (address) {
+    /// @dev Override to check blacklist and pause on all token movements.
+    function _update(address to, uint256 tokenId, address auth) internal override whenNotPaused returns (address) {
         address from = _ownerOf(tokenId);
 
         if (from != address(0) && to != address(0)) {

--- a/src/WithdrawalQueueERC721.sol
+++ b/src/WithdrawalQueueERC721.sol
@@ -158,7 +158,7 @@ contract WithdrawalQueueERC721 is
     // ============ Processing Functions ============
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function lockRequests(uint256[] calldata tokenIds) external onlyRole(PROCESSOR_ROLE) {
+    function lockRequests(uint256[] calldata tokenIds) external whenNotPaused onlyRole(PROCESSOR_ROLE) {
         uint256 count = tokenIds.length;
         require(count > 0, InvalidInputs());
 
@@ -172,7 +172,7 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function unlockRequests(uint256[] calldata tokenIds) external onlyRole(PROCESSOR_ROLE) {
+    function unlockRequests(uint256[] calldata tokenIds) external whenNotPaused onlyRole(PROCESSOR_ROLE) {
         uint256 count = tokenIds.length;
         require(count > 0, InvalidInputs());
 
@@ -227,7 +227,7 @@ contract WithdrawalQueueERC721 is
         uint256 totalUsdatReceived,
         uint256 totalStrcSold,
         uint256 executionPrice
-    ) external nonReentrant onlyRole(PROCESSOR_ROLE) {
+    ) external nonReentrant whenNotPaused onlyRole(PROCESSOR_ROLE) {
         uint256 count = tokenIds.length;
         require(count > 0, InvalidInputs());
 

--- a/src/WithdrawalQueueERC721.sol
+++ b/src/WithdrawalQueueERC721.sol
@@ -8,7 +8,9 @@ import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {ERC721EnumerableUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
+import {
+    ERC721EnumerableUpgradeable
+} from "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
 import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
@@ -75,17 +77,12 @@ contract WithdrawalQueueERC721 is
     /// @param stakedUsdat The StakedUSDat proxy address (granted STAKED_USDAT_ROLE)
     /// @param processor The processor address (granted PROCESSOR_ROLE)
     /// @param compliance The compliance address (granted COMPLIANCE_ROLE)
-    function initialize(
-        address admin,
-        address stakedUsdat,
-        address processor,
-        address compliance
-    ) external initializer {
+    function initialize(address admin, address stakedUsdat, address processor, address compliance)
+        external
+        initializer
+    {
         require(
-            admin != address(0) &&
-                stakedUsdat != address(0) &&
-                processor != address(0) &&
-                compliance != address(0),
+            admin != address(0) && stakedUsdat != address(0) && processor != address(0) && compliance != address(0),
             ZeroAmount()
         );
 
@@ -101,9 +98,7 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @dev Authorizes an upgrade to a new implementation. Only callable by DEFAULT_ADMIN_ROLE.
-    function _authorizeUpgrade(
-        address
-    ) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+    function _authorizeUpgrade(address) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
 
     /// @dev Reverts if the given account is blacklisted in either StakedUSDat or USDat.
     function _requireNotBlacklisted(address account) internal view {
@@ -113,20 +108,13 @@ contract WithdrawalQueueERC721 is
 
     /// @dev Reverts if the given account is NOT blacklisted in both StakedUSDat and USDat.
     function _requireBlacklisted(address account) internal view {
-        require(
-            STAKED_USDAT.isBlacklisted(account) || USDAT.isFrozen(account),
-            NotBlacklisted()
-        );
+        require(STAKED_USDAT.isBlacklisted(account) || USDAT.isFrozen(account), NotBlacklisted());
     }
 
     // ============ Request Creation ============
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function addRequest(
-        address user,
-        uint256 shares,
-        uint256 minUsdatReceived
-    )
+    function addRequest(address user, uint256 shares, uint256 minUsdatReceived)
         external
         nonReentrant
         whenNotPaused
@@ -152,24 +140,14 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function updateMinUsdatReceived(
-        uint256 tokenId,
-        uint256 newMinUsdatReceived
-    ) external whenNotPaused {
+    function updateMinUsdatReceived(uint256 tokenId, uint256 newMinUsdatReceived) external whenNotPaused {
         require(ownerOf(tokenId) == msg.sender, NotOwner());
         _requireNotBlacklisted(msg.sender);
         Request storage req = requests[tokenId];
-        require(
-            req.status == RequestStatus.Requested ||
-                req.status == RequestStatus.InProgress,
-            AlreadyProcessed()
-        );
+        require(req.status == RequestStatus.Requested || req.status == RequestStatus.InProgress, AlreadyProcessed());
 
         if (req.status == RequestStatus.InProgress) {
-            require(
-                newMinUsdatReceived < req.minUsdatReceived,
-                InvalidInputs()
-            );
+            require(newMinUsdatReceived < req.minUsdatReceived, InvalidInputs());
         }
 
         req.minUsdatReceived = newMinUsdatReceived;
@@ -180,9 +158,7 @@ contract WithdrawalQueueERC721 is
     // ============ Processing Functions ============
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function lockRequests(
-        uint256[] calldata tokenIds
-    ) external onlyRole(PROCESSOR_ROLE) {
+    function lockRequests(uint256[] calldata tokenIds) external onlyRole(PROCESSOR_ROLE) {
         uint256 count = tokenIds.length;
         require(count > 0, InvalidInputs());
 
@@ -196,9 +172,7 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function unlockRequests(
-        uint256[] calldata tokenIds
-    ) external onlyRole(PROCESSOR_ROLE) {
+    function unlockRequests(uint256[] calldata tokenIds) external onlyRole(PROCESSOR_ROLE) {
         uint256 count = tokenIds.length;
         require(count > 0, InvalidInputs());
 
@@ -212,29 +186,15 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @dev Validates that usdatAmount meets the user's minimum requirement.
-    function _validateAmount(
-        uint256 usdatAmount,
-        uint256 minUsdatReceived
-    ) internal pure {
+    function _validateAmount(uint256 usdatAmount, uint256 minUsdatReceived) internal pure {
         require(usdatAmount >= minUsdatReceived, SlippageExceeded());
     }
 
     /// @dev Checks if a value is within ±toleranceBps of an expected value.
-    function _isWithinTolerance(
-        uint256 value,
-        uint256 expected
-    ) internal view returns (bool) {
+    function _isWithinTolerance(uint256 value, uint256 expected) internal view returns (bool) {
         uint256 toleranceBps = STAKED_USDAT.toleranceBps();
-        uint256 minExpected = Math.mulDiv(
-            expected,
-            BPS_DENOMINATOR - toleranceBps,
-            BPS_DENOMINATOR
-        );
-        uint256 maxExpected = Math.mulDiv(
-            expected,
-            BPS_DENOMINATOR + toleranceBps,
-            BPS_DENOMINATOR
-        );
+        uint256 minExpected = Math.mulDiv(expected, BPS_DENOMINATOR - toleranceBps, BPS_DENOMINATOR);
+        uint256 maxExpected = Math.mulDiv(expected, BPS_DENOMINATOR + toleranceBps, BPS_DENOMINATOR);
         return value >= minExpected && value <= maxExpected;
     }
 
@@ -250,30 +210,15 @@ contract WithdrawalQueueERC721 is
         uint256 vestedBalance = strcBalance - unvestedAmount;
         require(totalStrcSold <= vestedBalance, ExceedsVestedBalance());
 
-        (uint256 oraclePrice, uint8 priceDecimals) = IStrcPriceOracle(
-            STAKED_USDAT.getStrcOracle()
-        ).getPrice();
+        (uint256 oraclePrice, uint8 priceDecimals) = IStrcPriceOracle(STAKED_USDAT.getStrcOracle()).getPrice();
 
-        uint256 expectedUsdat = Math.mulDiv(
-            totalStrcSold,
-            executionPrice,
-            10 ** priceDecimals
-        );
-        require(
-            _isWithinTolerance(totalUsdatReceived, expectedUsdat),
-            ExecutionPriceMismatch()
-        );
+        uint256 expectedUsdat = Math.mulDiv(totalStrcSold, executionPrice, 10 ** priceDecimals);
+        require(_isWithinTolerance(totalUsdatReceived, expectedUsdat), ExecutionPriceMismatch());
 
-        require(
-            _isWithinTolerance(executionPrice, oraclePrice),
-            OraclePriceMismatch()
-        );
+        require(_isWithinTolerance(executionPrice, oraclePrice), OraclePriceMismatch());
 
         uint256 expectedShareValue = STAKED_USDAT.previewRedeem(totalShares);
-        require(
-            _isWithinTolerance(totalUsdatReceived, expectedShareValue),
-            ExecutionPriceMismatch()
-        );
+        require(_isWithinTolerance(totalUsdatReceived, expectedShareValue), ExecutionPriceMismatch());
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
@@ -291,24 +236,14 @@ contract WithdrawalQueueERC721 is
             totalShares += requests[tokenIds[i]].shares;
         }
 
-        _validateTotals(
-            totalUsdatReceived,
-            totalStrcSold,
-            executionPrice,
-            totalShares
-        );
+        _validateTotals(totalUsdatReceived, totalStrcSold, executionPrice, totalShares);
 
         uint256 totalUsdat = 0;
         for (uint256 i = 0; i < count; i++) {
             Request storage req = requests[tokenIds[i]];
             require(req.status == RequestStatus.InProgress, RequestNotLocked());
 
-            uint256 usdatAmount = Math.mulDiv(
-                totalUsdatReceived,
-                req.shares,
-                totalShares,
-                Math.Rounding.Floor
-            );
+            uint256 usdatAmount = Math.mulDiv(totalUsdatReceived, req.shares, totalShares, Math.Rounding.Floor);
 
             _validateAmount(usdatAmount, req.minUsdatReceived);
 
@@ -324,11 +259,7 @@ contract WithdrawalQueueERC721 is
         pendingCount -= count;
 
         STAKED_USDAT.burnQueuedShares(totalShares, totalStrcSold);
-        IERC20(address(USDAT)).safeTransferFrom(
-            msg.sender,
-            address(this),
-            totalUsdatReceived
-        );
+        IERC20(address(USDAT)).safeTransferFrom(msg.sender, address(this), totalUsdatReceived);
         uint256 dust = totalUsdatReceived - totalUsdat;
         if (dust > 0) {
             IERC20(address(USDAT)).approve(address(STAKED_USDAT), dust);
@@ -339,9 +270,7 @@ contract WithdrawalQueueERC721 is
     // ============ Claiming Functions ============
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function claim(
-        uint256 tokenId
-    ) external nonReentrant whenNotPaused returns (uint256 amount) {
+    function claim(uint256 tokenId) external nonReentrant whenNotPaused returns (uint256 amount) {
         _requireNotBlacklisted(msg.sender);
         require(ownerOf(tokenId) == msg.sender, NotOwner());
 
@@ -359,9 +288,7 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function claimBatch(
-        uint256[] calldata tokenIds
-    ) external nonReentrant whenNotPaused returns (uint256 totalAmount) {
+    function claimBatch(uint256[] calldata tokenIds) external nonReentrant whenNotPaused returns (uint256 totalAmount) {
         _requireNotBlacklisted(msg.sender);
         uint256 len = tokenIds.length;
         require(len > 0, ZeroAmount());
@@ -371,10 +298,7 @@ contract WithdrawalQueueERC721 is
             require(ownerOf(tokenId) == msg.sender, NotOwner());
 
             Request storage req = requests[tokenId];
-            require(
-                req.status == RequestStatus.Processed,
-                RequestNotProcessed()
-            );
+            require(req.status == RequestStatus.Processed, RequestNotProcessed());
 
             totalAmount += req.usdatOwed;
             req.status = RequestStatus.Claimed;
@@ -388,10 +312,7 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function claimBatchFor(
-        address user,
-        uint256[] calldata tokenIds
-    )
+    function claimBatchFor(address user, uint256[] calldata tokenIds)
         external
         nonReentrant
         whenNotPaused
@@ -407,10 +328,7 @@ contract WithdrawalQueueERC721 is
             require(ownerOf(tokenId) == user, NotOwner());
 
             Request storage req = requests[tokenId];
-            require(
-                req.status == RequestStatus.Processed,
-                RequestNotProcessed()
-            );
+            require(req.status == RequestStatus.Processed, RequestNotProcessed());
 
             totalAmount += req.usdatOwed;
             req.status = RequestStatus.Claimed;
@@ -424,20 +342,13 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function claimAll()
-        external
-        nonReentrant
-        whenNotPaused
-        returns (uint256 totalAmount)
-    {
+    function claimAll() external nonReentrant whenNotPaused returns (uint256 totalAmount) {
         _requireNotBlacklisted(msg.sender);
         totalAmount = _claimAllFor(msg.sender);
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function claimAllFor(
-        address user
-    )
+    function claimAllFor(address user)
         external
         nonReentrant
         whenNotPaused
@@ -482,16 +393,12 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function getUserRequests(
-        address user
-    ) external view returns (uint256[] memory tokenIds) {
+    function getUserRequests(address user) external view returns (uint256[] memory tokenIds) {
         return _getTokensOf(user);
     }
 
     /// @dev Returns all token IDs owned by an address.
-    function _getTokensOf(
-        address user
-    ) internal view returns (uint256[] memory tokenIds) {
+    function _getTokensOf(address user) internal view returns (uint256[] memory tokenIds) {
         uint256 balance = balanceOf(user);
         tokenIds = new uint256[](balance);
         for (uint256 i = 0; i < balance; i++) {
@@ -500,9 +407,7 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function getClaimable(
-        address user
-    ) external view returns (uint256 total, uint256[] memory claimableIds) {
+    function getClaimable(address user) external view returns (uint256 total, uint256[] memory claimableIds) {
         uint256 balance = balanceOf(user);
         uint256[] memory temp = new uint256[](balance);
         uint256 count = 0;
@@ -523,9 +428,7 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function getPending(
-        address user
-    ) external view returns (uint256 totalShares, uint256[] memory pendingIds) {
+    function getPending(address user) external view returns (uint256 totalShares, uint256[] memory pendingIds) {
         uint256 balance = balanceOf(user);
         uint256[] memory temp = new uint256[](balance);
         uint256 count = 0;
@@ -533,10 +436,7 @@ contract WithdrawalQueueERC721 is
         for (uint256 i = 0; i < balance; i++) {
             uint256 tokenId = tokenOfOwnerByIndex(user, i);
             Request storage req = requests[tokenId];
-            if (
-                req.status == RequestStatus.Requested ||
-                req.status == RequestStatus.InProgress
-            ) {
+            if (req.status == RequestStatus.Requested || req.status == RequestStatus.InProgress) {
                 temp[count++] = tokenId;
                 totalShares += req.shares;
             }
@@ -549,9 +449,7 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function getRequest(
-        uint256 tokenId
-    ) external view returns (Request memory) {
+    function getRequest(uint256 tokenId) external view returns (Request memory) {
         return requests[tokenId];
     }
 
@@ -581,10 +479,7 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function getPendingIdsInRange(
-        uint256 start,
-        uint256 end
-    ) external view returns (uint256[] memory pendingIds) {
+    function getPendingIdsInRange(uint256 start, uint256 end) external view returns (uint256[] memory pendingIds) {
         require(start < end, InvalidInputs());
         if (end > nextTokenId) {
             end = nextTokenId;
@@ -595,10 +490,7 @@ contract WithdrawalQueueERC721 is
 
         for (uint256 i = start; i < end; i++) {
             RequestStatus status = requests[i].status;
-            if (
-                status == RequestStatus.Requested ||
-                status == RequestStatus.InProgress
-            ) {
+            if (status == RequestStatus.Requested || status == RequestStatus.InProgress) {
                 temp[count++] = i;
             }
         }
@@ -612,10 +504,7 @@ contract WithdrawalQueueERC721 is
     // ============ Compliance Functions ============
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function seizeRequests(
-        uint256[] calldata tokenIds,
-        address to
-    ) external nonReentrant onlyRole(COMPLIANCE_ROLE) {
+    function seizeRequests(uint256[] calldata tokenIds, address to) external nonReentrant onlyRole(COMPLIANCE_ROLE) {
         require(to != address(0), ZeroAmount());
         _requireNotBlacklisted(to);
 
@@ -628,11 +517,7 @@ contract WithdrawalQueueERC721 is
             _requireBlacklisted(owner);
 
             Request storage req = requests[tokenId];
-            require(
-                req.status == RequestStatus.Requested ||
-                    req.status == RequestStatus.InProgress,
-                AlreadyProcessed()
-            );
+            require(req.status == RequestStatus.Requested || req.status == RequestStatus.InProgress, AlreadyProcessed());
 
             _transfer(owner, to, tokenId);
 
@@ -641,10 +526,11 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function seizeBlacklistedFunds(
-        uint256[] calldata tokenIds,
-        address to
-    ) external nonReentrant onlyRole(COMPLIANCE_ROLE) {
+    function seizeBlacklistedFunds(uint256[] calldata tokenIds, address to)
+        external
+        nonReentrant
+        onlyRole(COMPLIANCE_ROLE)
+    {
         require(to != address(0), ZeroAmount());
         uint256 len = tokenIds.length;
         require(len > 0, ZeroAmount());
@@ -657,10 +543,7 @@ contract WithdrawalQueueERC721 is
             _requireBlacklisted(owner);
 
             Request storage req = requests[tokenId];
-            require(
-                req.status == RequestStatus.Processed,
-                RequestNotProcessed()
-            );
+            require(req.status == RequestStatus.Processed, RequestNotProcessed());
 
             totalUsdatSeized += req.usdatOwed;
             req.status = RequestStatus.Claimed;
@@ -686,11 +569,7 @@ contract WithdrawalQueueERC721 is
     // ============ Required Overrides ============
 
     /// @dev Override to check blacklist on transfers.
-    function _update(
-        address to,
-        uint256 tokenId,
-        address auth
-    ) internal override returns (address) {
+    function _update(address to, uint256 tokenId, address auth) internal override returns (address) {
         address from = _ownerOf(tokenId);
 
         if (from != address(0) && to != address(0)) {
@@ -707,9 +586,7 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @dev Override required by Solidity for multiple inheritance.
-    function supportsInterface(
-        bytes4 interfaceId
-    )
+    function supportsInterface(bytes4 interfaceId)
         public
         view
         override(ERC721EnumerableUpgradeable, AccessControlUpgradeable)

--- a/src/WithdrawalQueueERC721.sol
+++ b/src/WithdrawalQueueERC721.sol
@@ -8,9 +8,7 @@ import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {
-    ERC721EnumerableUpgradeable
-} from "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
+import {ERC721EnumerableUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
 import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
@@ -77,12 +75,17 @@ contract WithdrawalQueueERC721 is
     /// @param stakedUsdat The StakedUSDat proxy address (granted STAKED_USDAT_ROLE)
     /// @param processor The processor address (granted PROCESSOR_ROLE)
     /// @param compliance The compliance address (granted COMPLIANCE_ROLE)
-    function initialize(address admin, address stakedUsdat, address processor, address compliance)
-        external
-        initializer
-    {
+    function initialize(
+        address admin,
+        address stakedUsdat,
+        address processor,
+        address compliance
+    ) external initializer {
         require(
-            admin != address(0) && stakedUsdat != address(0) && processor != address(0) && compliance != address(0),
+            admin != address(0) &&
+                stakedUsdat != address(0) &&
+                processor != address(0) &&
+                compliance != address(0),
             ZeroAmount()
         );
 
@@ -98,7 +101,9 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @dev Authorizes an upgrade to a new implementation. Only callable by DEFAULT_ADMIN_ROLE.
-    function _authorizeUpgrade(address) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+    function _authorizeUpgrade(
+        address
+    ) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
 
     /// @dev Reverts if the given account is blacklisted in either StakedUSDat or USDat.
     function _requireNotBlacklisted(address account) internal view {
@@ -108,13 +113,20 @@ contract WithdrawalQueueERC721 is
 
     /// @dev Reverts if the given account is NOT blacklisted in both StakedUSDat and USDat.
     function _requireBlacklisted(address account) internal view {
-        require(STAKED_USDAT.isBlacklisted(account) || USDAT.isFrozen(account), NotBlacklisted());
+        require(
+            STAKED_USDAT.isBlacklisted(account) || USDAT.isFrozen(account),
+            NotBlacklisted()
+        );
     }
 
     // ============ Request Creation ============
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function addRequest(address user, uint256 shares, uint256 minUsdatReceived)
+    function addRequest(
+        address user,
+        uint256 shares,
+        uint256 minUsdatReceived
+    )
         external
         nonReentrant
         whenNotPaused
@@ -140,14 +152,24 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function updateMinUsdatReceived(uint256 tokenId, uint256 newMinUsdatReceived) external whenNotPaused {
+    function updateMinUsdatReceived(
+        uint256 tokenId,
+        uint256 newMinUsdatReceived
+    ) external whenNotPaused {
         require(ownerOf(tokenId) == msg.sender, NotOwner());
         _requireNotBlacklisted(msg.sender);
         Request storage req = requests[tokenId];
-        require(req.status == RequestStatus.Requested || req.status == RequestStatus.InProgress, AlreadyProcessed());
+        require(
+            req.status == RequestStatus.Requested ||
+                req.status == RequestStatus.InProgress,
+            AlreadyProcessed()
+        );
 
         if (req.status == RequestStatus.InProgress) {
-            require(newMinUsdatReceived < req.minUsdatReceived, InvalidInputs());
+            require(
+                newMinUsdatReceived < req.minUsdatReceived,
+                InvalidInputs()
+            );
         }
 
         req.minUsdatReceived = newMinUsdatReceived;
@@ -158,7 +180,9 @@ contract WithdrawalQueueERC721 is
     // ============ Processing Functions ============
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function lockRequests(uint256[] calldata tokenIds) external whenNotPaused onlyRole(PROCESSOR_ROLE) {
+    function lockRequests(
+        uint256[] calldata tokenIds
+    ) external onlyRole(PROCESSOR_ROLE) {
         uint256 count = tokenIds.length;
         require(count > 0, InvalidInputs());
 
@@ -172,7 +196,9 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function unlockRequests(uint256[] calldata tokenIds) external whenNotPaused onlyRole(PROCESSOR_ROLE) {
+    function unlockRequests(
+        uint256[] calldata tokenIds
+    ) external onlyRole(PROCESSOR_ROLE) {
         uint256 count = tokenIds.length;
         require(count > 0, InvalidInputs());
 
@@ -186,15 +212,29 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @dev Validates that usdatAmount meets the user's minimum requirement.
-    function _validateAmount(uint256 usdatAmount, uint256 minUsdatReceived) internal pure {
+    function _validateAmount(
+        uint256 usdatAmount,
+        uint256 minUsdatReceived
+    ) internal pure {
         require(usdatAmount >= minUsdatReceived, SlippageExceeded());
     }
 
     /// @dev Checks if a value is within ±toleranceBps of an expected value.
-    function _isWithinTolerance(uint256 value, uint256 expected) internal view returns (bool) {
+    function _isWithinTolerance(
+        uint256 value,
+        uint256 expected
+    ) internal view returns (bool) {
         uint256 toleranceBps = STAKED_USDAT.toleranceBps();
-        uint256 minExpected = Math.mulDiv(expected, BPS_DENOMINATOR - toleranceBps, BPS_DENOMINATOR);
-        uint256 maxExpected = Math.mulDiv(expected, BPS_DENOMINATOR + toleranceBps, BPS_DENOMINATOR);
+        uint256 minExpected = Math.mulDiv(
+            expected,
+            BPS_DENOMINATOR - toleranceBps,
+            BPS_DENOMINATOR
+        );
+        uint256 maxExpected = Math.mulDiv(
+            expected,
+            BPS_DENOMINATOR + toleranceBps,
+            BPS_DENOMINATOR
+        );
         return value >= minExpected && value <= maxExpected;
     }
 
@@ -210,15 +250,30 @@ contract WithdrawalQueueERC721 is
         uint256 vestedBalance = strcBalance - unvestedAmount;
         require(totalStrcSold <= vestedBalance, ExceedsVestedBalance());
 
-        (uint256 oraclePrice, uint8 priceDecimals) = IStrcPriceOracle(STAKED_USDAT.getStrcOracle()).getPrice();
+        (uint256 oraclePrice, uint8 priceDecimals) = IStrcPriceOracle(
+            STAKED_USDAT.getStrcOracle()
+        ).getPrice();
 
-        uint256 expectedUsdat = Math.mulDiv(totalStrcSold, executionPrice, 10 ** priceDecimals);
-        require(_isWithinTolerance(totalUsdatReceived, expectedUsdat), ExecutionPriceMismatch());
+        uint256 expectedUsdat = Math.mulDiv(
+            totalStrcSold,
+            executionPrice,
+            10 ** priceDecimals
+        );
+        require(
+            _isWithinTolerance(totalUsdatReceived, expectedUsdat),
+            ExecutionPriceMismatch()
+        );
 
-        require(_isWithinTolerance(executionPrice, oraclePrice), OraclePriceMismatch());
+        require(
+            _isWithinTolerance(executionPrice, oraclePrice),
+            OraclePriceMismatch()
+        );
 
         uint256 expectedShareValue = STAKED_USDAT.previewRedeem(totalShares);
-        require(_isWithinTolerance(totalUsdatReceived, expectedShareValue), ExecutionPriceMismatch());
+        require(
+            _isWithinTolerance(totalUsdatReceived, expectedShareValue),
+            ExecutionPriceMismatch()
+        );
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
@@ -227,7 +282,7 @@ contract WithdrawalQueueERC721 is
         uint256 totalUsdatReceived,
         uint256 totalStrcSold,
         uint256 executionPrice
-    ) external nonReentrant whenNotPaused onlyRole(PROCESSOR_ROLE) {
+    ) external nonReentrant onlyRole(PROCESSOR_ROLE) {
         uint256 count = tokenIds.length;
         require(count > 0, InvalidInputs());
 
@@ -236,14 +291,24 @@ contract WithdrawalQueueERC721 is
             totalShares += requests[tokenIds[i]].shares;
         }
 
-        _validateTotals(totalUsdatReceived, totalStrcSold, executionPrice, totalShares);
+        _validateTotals(
+            totalUsdatReceived,
+            totalStrcSold,
+            executionPrice,
+            totalShares
+        );
 
         uint256 totalUsdat = 0;
         for (uint256 i = 0; i < count; i++) {
             Request storage req = requests[tokenIds[i]];
             require(req.status == RequestStatus.InProgress, RequestNotLocked());
 
-            uint256 usdatAmount = Math.mulDiv(totalUsdatReceived, req.shares, totalShares, Math.Rounding.Floor);
+            uint256 usdatAmount = Math.mulDiv(
+                totalUsdatReceived,
+                req.shares,
+                totalShares,
+                Math.Rounding.Floor
+            );
 
             _validateAmount(usdatAmount, req.minUsdatReceived);
 
@@ -259,7 +324,11 @@ contract WithdrawalQueueERC721 is
         pendingCount -= count;
 
         STAKED_USDAT.burnQueuedShares(totalShares, totalStrcSold);
-        IERC20(address(USDAT)).safeTransferFrom(msg.sender, address(this), totalUsdatReceived);
+        IERC20(address(USDAT)).safeTransferFrom(
+            msg.sender,
+            address(this),
+            totalUsdatReceived
+        );
         uint256 dust = totalUsdatReceived - totalUsdat;
         if (dust > 0) {
             IERC20(address(USDAT)).approve(address(STAKED_USDAT), dust);
@@ -270,7 +339,9 @@ contract WithdrawalQueueERC721 is
     // ============ Claiming Functions ============
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function claim(uint256 tokenId) external nonReentrant whenNotPaused returns (uint256 amount) {
+    function claim(
+        uint256 tokenId
+    ) external nonReentrant whenNotPaused returns (uint256 amount) {
         _requireNotBlacklisted(msg.sender);
         require(ownerOf(tokenId) == msg.sender, NotOwner());
 
@@ -288,7 +359,9 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function claimBatch(uint256[] calldata tokenIds) external nonReentrant whenNotPaused returns (uint256 totalAmount) {
+    function claimBatch(
+        uint256[] calldata tokenIds
+    ) external nonReentrant whenNotPaused returns (uint256 totalAmount) {
         _requireNotBlacklisted(msg.sender);
         uint256 len = tokenIds.length;
         require(len > 0, ZeroAmount());
@@ -298,7 +371,10 @@ contract WithdrawalQueueERC721 is
             require(ownerOf(tokenId) == msg.sender, NotOwner());
 
             Request storage req = requests[tokenId];
-            require(req.status == RequestStatus.Processed, RequestNotProcessed());
+            require(
+                req.status == RequestStatus.Processed,
+                RequestNotProcessed()
+            );
 
             totalAmount += req.usdatOwed;
             req.status = RequestStatus.Claimed;
@@ -312,7 +388,10 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function claimBatchFor(address user, uint256[] calldata tokenIds)
+    function claimBatchFor(
+        address user,
+        uint256[] calldata tokenIds
+    )
         external
         nonReentrant
         whenNotPaused
@@ -328,7 +407,10 @@ contract WithdrawalQueueERC721 is
             require(ownerOf(tokenId) == user, NotOwner());
 
             Request storage req = requests[tokenId];
-            require(req.status == RequestStatus.Processed, RequestNotProcessed());
+            require(
+                req.status == RequestStatus.Processed,
+                RequestNotProcessed()
+            );
 
             totalAmount += req.usdatOwed;
             req.status = RequestStatus.Claimed;
@@ -342,13 +424,20 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function claimAll() external nonReentrant whenNotPaused returns (uint256 totalAmount) {
+    function claimAll()
+        external
+        nonReentrant
+        whenNotPaused
+        returns (uint256 totalAmount)
+    {
         _requireNotBlacklisted(msg.sender);
         totalAmount = _claimAllFor(msg.sender);
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function claimAllFor(address user)
+    function claimAllFor(
+        address user
+    )
         external
         nonReentrant
         whenNotPaused
@@ -393,12 +482,16 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function getUserRequests(address user) external view returns (uint256[] memory tokenIds) {
+    function getUserRequests(
+        address user
+    ) external view returns (uint256[] memory tokenIds) {
         return _getTokensOf(user);
     }
 
     /// @dev Returns all token IDs owned by an address.
-    function _getTokensOf(address user) internal view returns (uint256[] memory tokenIds) {
+    function _getTokensOf(
+        address user
+    ) internal view returns (uint256[] memory tokenIds) {
         uint256 balance = balanceOf(user);
         tokenIds = new uint256[](balance);
         for (uint256 i = 0; i < balance; i++) {
@@ -407,7 +500,9 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function getClaimable(address user) external view returns (uint256 total, uint256[] memory claimableIds) {
+    function getClaimable(
+        address user
+    ) external view returns (uint256 total, uint256[] memory claimableIds) {
         uint256 balance = balanceOf(user);
         uint256[] memory temp = new uint256[](balance);
         uint256 count = 0;
@@ -428,7 +523,9 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function getPending(address user) external view returns (uint256 totalShares, uint256[] memory pendingIds) {
+    function getPending(
+        address user
+    ) external view returns (uint256 totalShares, uint256[] memory pendingIds) {
         uint256 balance = balanceOf(user);
         uint256[] memory temp = new uint256[](balance);
         uint256 count = 0;
@@ -436,7 +533,10 @@ contract WithdrawalQueueERC721 is
         for (uint256 i = 0; i < balance; i++) {
             uint256 tokenId = tokenOfOwnerByIndex(user, i);
             Request storage req = requests[tokenId];
-            if (req.status == RequestStatus.Requested || req.status == RequestStatus.InProgress) {
+            if (
+                req.status == RequestStatus.Requested ||
+                req.status == RequestStatus.InProgress
+            ) {
                 temp[count++] = tokenId;
                 totalShares += req.shares;
             }
@@ -449,7 +549,9 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function getRequest(uint256 tokenId) external view returns (Request memory) {
+    function getRequest(
+        uint256 tokenId
+    ) external view returns (Request memory) {
         return requests[tokenId];
     }
 
@@ -479,7 +581,10 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function getPendingIdsInRange(uint256 start, uint256 end) external view returns (uint256[] memory pendingIds) {
+    function getPendingIdsInRange(
+        uint256 start,
+        uint256 end
+    ) external view returns (uint256[] memory pendingIds) {
         require(start < end, InvalidInputs());
         if (end > nextTokenId) {
             end = nextTokenId;
@@ -490,7 +595,10 @@ contract WithdrawalQueueERC721 is
 
         for (uint256 i = start; i < end; i++) {
             RequestStatus status = requests[i].status;
-            if (status == RequestStatus.Requested || status == RequestStatus.InProgress) {
+            if (
+                status == RequestStatus.Requested ||
+                status == RequestStatus.InProgress
+            ) {
                 temp[count++] = i;
             }
         }
@@ -504,7 +612,10 @@ contract WithdrawalQueueERC721 is
     // ============ Compliance Functions ============
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function seizeRequests(uint256[] calldata tokenIds, address to) external nonReentrant onlyRole(COMPLIANCE_ROLE) {
+    function seizeRequests(
+        uint256[] calldata tokenIds,
+        address to
+    ) external nonReentrant onlyRole(COMPLIANCE_ROLE) {
         require(to != address(0), ZeroAmount());
         _requireNotBlacklisted(to);
 
@@ -517,7 +628,11 @@ contract WithdrawalQueueERC721 is
             _requireBlacklisted(owner);
 
             Request storage req = requests[tokenId];
-            require(req.status == RequestStatus.Requested || req.status == RequestStatus.InProgress, AlreadyProcessed());
+            require(
+                req.status == RequestStatus.Requested ||
+                    req.status == RequestStatus.InProgress,
+                AlreadyProcessed()
+            );
 
             _transfer(owner, to, tokenId);
 
@@ -526,11 +641,10 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @inheritdoc IWithdrawalQueueERC721
-    function seizeBlacklistedFunds(uint256[] calldata tokenIds, address to)
-        external
-        nonReentrant
-        onlyRole(COMPLIANCE_ROLE)
-    {
+    function seizeBlacklistedFunds(
+        uint256[] calldata tokenIds,
+        address to
+    ) external nonReentrant onlyRole(COMPLIANCE_ROLE) {
         require(to != address(0), ZeroAmount());
         uint256 len = tokenIds.length;
         require(len > 0, ZeroAmount());
@@ -543,7 +657,10 @@ contract WithdrawalQueueERC721 is
             _requireBlacklisted(owner);
 
             Request storage req = requests[tokenId];
-            require(req.status == RequestStatus.Processed, RequestNotProcessed());
+            require(
+                req.status == RequestStatus.Processed,
+                RequestNotProcessed()
+            );
 
             totalUsdatSeized += req.usdatOwed;
             req.status = RequestStatus.Claimed;
@@ -569,7 +686,11 @@ contract WithdrawalQueueERC721 is
     // ============ Required Overrides ============
 
     /// @dev Override to check blacklist on transfers.
-    function _update(address to, uint256 tokenId, address auth) internal override returns (address) {
+    function _update(
+        address to,
+        uint256 tokenId,
+        address auth
+    ) internal override returns (address) {
         address from = _ownerOf(tokenId);
 
         if (from != address(0) && to != address(0)) {
@@ -586,7 +707,9 @@ contract WithdrawalQueueERC721 is
     }
 
     /// @dev Override required by Solidity for multiple inheritance.
-    function supportsInterface(bytes4 interfaceId)
+    function supportsInterface(
+        bytes4 interfaceId
+    )
         public
         view
         override(ERC721EnumerableUpgradeable, AccessControlUpgradeable)


### PR DESCRIPTION
### Issues:
1. sUSDat previously did not have transfer and transferFrom
2. PROCESSOR_ROLE controled both parameters and daily functions

### Fixes
1. In StakedUSDat, override `_update` to support `whenNotPaused` enforcing freezing of the entire contract. 
2. Support the ability to `redistributeLockedAmount` when the contract is paused. This allows us to recall blacklisted funds and clean up the issue without having to unpause the contract.
3. Clean up the `PROCESSOR_ROLE` to have only control daily functions and not vault parameters

### Notes
1. Fix 1 stops the ability to process requests when the contract is paused, the `ProcessRequest` function will fail on on  `burnQueuedShares`


### Future improvements
1. simplify the claims to support only claim by token id
2. simplify the recall of blacklisted funds and remove the forloop


[Audit]
- The Certora Team provided a review of the changes made in this PR and approved everything with no issues