### PR TITLE
FIX: invariant strcBalance >= getUnvestedAmount

### DIFF
--- a/src/StakedUSDat.sol
+++ b/src/StakedUSDat.sol
@@ -590,6 +590,7 @@ contract StakedUSDat is
 
         uint256 oldPeriod = vestingPeriod;
         vestingPeriod = newVestingPeriod;
+        vestingAmount = 0;
 
         emit VestingPeriodUpdated(oldPeriod, newVestingPeriod);
     }


### PR DESCRIPTION
The error was caught in a formal verification by Certora. And the update was approved by the team.

Since the vestingAmount is never cleared (after vesting completes) and if strc is sold afterwards, strc bal will drop bellow the stale vestingAmount. Extending the vesting period then reactivates it. Example:
vestingAmount = 25 strc, vesting completes after 30 days.
Processor sell all strc. 7 days later, processor extends the vesting period to 90. Now getUnvestedAmount will return - ((90-38) * 25) / 90 = 14.
Now, _strcTotalAssets underflows, because strcBalance - getUnvestedAmount = (0 - 14)