### PR TITLE
docs: rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,189 @@
-## Foundry
+# saturn-yield-dollar — sUSDat
 
-**Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.**
+sUSDat is Saturn's yield-bearing stablecoin vault. Users deposit USDat (from [saturn-dollar](https://github.com/saturn-organization/saturn-dollar)) and receive sUSDat shares. The protocol rotates the USDat backing into STRC (Strategy Inc.'s variable-rate perpetual preferred stock, currently yielding ~11.5% p.a.), passing dividends through as a rising sUSDat:USDat exchange rate.
 
-Foundry consists of:
+## How it works
 
-- **Forge**: Ethereum testing framework (like Truffle, Hardhat and DappTools).
-- **Cast**: Swiss army knife for interacting with EVM smart contracts, sending transactions and getting chain data.
-- **Anvil**: Local Ethereum node, akin to Ganache, Hardhat Network.
-- **Chisel**: Fast, utilitarian, and verbose solidity REPL.
+```mermaid
+flowchart TB
+    subgraph OnChain["On-chain"]
+        V["StakedUSDat\n(ERC-4626 vault)"]
+        Q["WithdrawalQueueERC721\n(NFT receipts)"]
+    end
+    subgraph OffChain["Off-chain — Saturn Fund Ltd"]
+        G["Galaxy / ClearStreet\n(STRC trading)"]
+    end
 
-## Documentation
-
-https://book.getfoundry.sh/
-
-## Usage
-
-### Build
-
-```shell
-$ forge build
+    User -->|"deposit(USDat)"| V
+    V -->|"sUSDat shares"| User
+    V -->|"convertFromUsdat()\n[PROCESSOR_ROLE]"| G
+    G -->|"convertFromStrc()\nSTRC balance credited"| V
+    G -->|"monthly dividend\ntransferInRewards()"| V
+    User -->|"requestRedeem(shares)"| Q
+    Q -->|"NFT receipt minted"| User
+    Q -->|"processRequests()\n[PROCESSOR_ROLE]"| Q
+    User -->|"claim(tokenId)"| Q
+    Q -->|"USDat returned"| User
 ```
 
-### Test
+**Share price formula:**
 
-```shell
-$ forge test
+```
+totalAssets = usdatBalance + (strcBalance_vested × strcPrice)
+sharePrice  = totalAssets / sUSDat.totalSupply()
 ```
 
-### Format
+STRC rewards vest linearly over `vestingPeriod` (default 30 days) to smooth the monthly dividend step.
 
-```shell
-$ forge fmt
+## Contracts
+
+```
+src/
+├── StakedUSDat.sol              # ERC4626 vault, UUPS upgradeable
+├── WithdrawalQueueERC721.sol    # NFT-based withdrawal queue, UUPS upgradeable
+├── StrcPriceOracle.sol          # Chainlink wrapper with staleness + bounds checks
+└── interfaces/
+    ├── IStakedUSDat.sol
+    ├── IWithdrawalQueueERC721.sol
+    ├── IStrcPriceOracle.sol
+    ├── IPriceOracle.sol
+    ├── IUSDat.sol
+    ├── IFreezable.sol
+    └── IERC20PermitExtended.sol
+
+script/
+├── Deploy.s.sol                       # Deploy all three contracts via CreateX
+├── UpgradeStakedUSDat.s.sol
+├── UpgradeWithdrawalQueueERC721.s.sol
+├── DeployMockOracle.s.sol             # Testnet mock oracle
+├── OracleHeartbeat.s.sol              # Testnet: keep mock oracle fresh
+└── README.md                          # Full deployment reference
+
+abi/
+├── StakedUSDat.json
+├── WithdrawalQueueERC721.json
+└── StrcPriceOracle.json
 ```
 
-### Gas Snapshots
+### StakedUSDat — key parameters
 
-```shell
-$ forge snapshot
+| Parameter | Default | Notes |
+|---|---|---|
+| Deposit fee | 10 bps (0.1%) | Capped at 500 bps; 0 = no fee |
+| Vesting period | 30 days | Max 90 days; rewards vest linearly |
+| Min withdrawal | 10 USDat | Hard-coded |
+| Price tolerance | 20% | Acceptable deviation between execution and oracle price |
+| Max rewards/transfer | 2.5% of totalAssets | Guard against oracle manipulation |
+| Decimals offset | 12 | ERC4626 inflation-attack mitigation |
+
+### StrcPriceOracle — key parameters
+
+| Parameter | Default | Notes |
+|---|---|---|
+| Max staleness | 26 hours | Oracle heartbeat is 24 hrs on Ethereum; hard cap 36 hrs |
+| Min price | $20 (20e8) | Sanity bound |
+| Max price | $150 (150e8) | Sanity bound |
+| Decimals | 8 | Chainlink-compatible |
+
+### Roles
+
+**StakedUSDat**
+
+| Role | Can do |
+|---|---|
+| `DEFAULT_ADMIN_ROLE` | Upgrade implementation, set fees, set vesting period, unpause, redistribute blacklisted funds |
+| `PROCESSOR_ROLE` | `convertFromUsdat()`, `convertFromStrc()`, `transferInRewards()` |
+| `COMPLIANCE_ROLE` | Pause, blacklist/unblacklist addresses |
+
+**WithdrawalQueueERC721**
+
+| Role | Can do |
+|---|---|
+| `DEFAULT_ADMIN_ROLE` | Upgrade, unpause |
+| `PROCESSOR_ROLE` | `lockRequests()`, `unlockRequests()`, `processRequests()` |
+| `STAKED_USDAT_ROLE` | `addRequest()`, `claimAllFor()`, `claimBatchFor()` |
+| `COMPLIANCE_ROLE` | Pause, `seizeRequests()`, `seizeBlacklistedFunds()` |
+
+## Withdrawal queue lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Requested : requestRedeem() [user]
+    Requested --> InProgress : lockRequests() [processor]
+    InProgress --> Requested : unlockRequests() [processor]
+    InProgress --> Processed : processRequests() [processor]
+    Processed --> Claimed : claim() / claimAll() [user]
+    Claimed --> [*]
 ```
 
-### Anvil
+Users can update `minUsdatReceived` on a `Requested` or `InProgress` position (only downward when `InProgress`). Positions can also be transferred as NFTs between wallets.
 
-```shell
-$ anvil
+## Deployed addresses
+
+| Network | Contract | Proxy |
+|---|---|---|
+| Ethereum mainnet | StakedUSDat | `0xd166337499e176bbc38a1fbd113ab144e5bd2df7` |
+| Ethereum mainnet | WithdrawalQueueERC721 | see Etherscan (linked from proxy) |
+| Ethereum mainnet | StrcPriceOracle | see Etherscan |
+| Sepolia testnet | StakedUSDat | `0xD166337499E176bbC38a1FBd113Ab144e5bd2Df7` |
+| Sepolia testnet | WithdrawalQueueERC721 | `0x4Bc9FEC04F0F95e9b42a3EF18F3C96fB57923D2e` |
+| Sepolia testnet | StrcPriceOracle | `0x5f7eCD0D045c393da6cb6c933c671AC305A871BF` |
+
+Proxy addresses are deterministic via [CreateX](https://github.com/pcaversaccio/createx) — same address on all chains for the same deployer and salt. See `script/README.md` for salt strings.
+
+## Development
+
+```bash
+forge install
+forge build
+forge test
+forge fmt
 ```
 
-### Deploy
+## Deployment
 
-```shell
-$ forge script script/Counter.s.sol:CounterScript --rpc-url <your_rpc_url> --private-key <your_private_key>
+Set the following in `.env` (see `script/README.md` for full reference):
+
+```bash
+PRIVATE_KEY=<deployer key>
+RPC_URL=<rpc endpoint>
+USDAT=<USDat proxy address>
+ORACLE=<Chainlink STRC oracle address>
+ETHERSCAN_API_KEY=<api key>
+
+# Optional (default to deployer if unset)
+ADMIN=<admin address>
+PROCESSOR=<processor address>
+COMPLIANCE=<compliance address>
+DEPOSIT_FEE_RECIPIENT=<fee recipient address>
 ```
 
-### Cast
-
-```shell
-$ cast <subcommand>
+```bash
+source .env && forge script script/Deploy.s.sol \
+  --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast
 ```
 
-### Help
+To upgrade implementations:
 
-```shell
-$ forge --help
-$ anvil --help
-$ cast --help
+```bash
+forge script script/UpgradeStakedUSDat.s.sol --rpc-url $RPC_URL --broadcast
+forge script script/UpgradeWithdrawalQueueERC721.s.sol --rpc-url $RPC_URL --broadcast
 ```
+
+For testnet, deploy and keep the mock oracle alive:
+
+```bash
+forge script script/DeployMockOracle.s.sol --rpc-url $RPC_URL --broadcast
+MOCK_ORACLE=<address> forge script script/OracleHeartbeat.s.sol --rpc-url $RPC_URL --broadcast
+```
+
+## Dependencies
+
+- [OpenZeppelin Contracts Upgradeable](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable) v5 — ERC4626, ERC721, AccessControl, UUPS, Pausable
+- [pcaversaccio/createx](https://github.com/pcaversaccio/createx) — deterministic cross-chain deployment
+
+## Security
+
+Audited by Three Sigma, Certora, and Cerotra. Reports are available on the Saturn GitBook.
+
+Both StakedUSDat and WithdrawalQueueERC721 use `UUPSUpgradeable`. Upgrades are gated by `DEFAULT_ADMIN_ROLE`.

--- a/src/StakedUSDat.sol
+++ b/src/StakedUSDat.sol
@@ -86,6 +86,12 @@ contract StakedUSDat is
     /// @notice Maximum deposit fee (5%)
     uint256 public constant MAX_DEPOSIT_FEE_BPS = 500;
 
+    /// @notice Maximum oracle price tolerance (10%)
+    uint256 public constant MAX_ORACLE_TOLERANCE_BPS = 1000;
+
+    /// @notice Minimum oracle price tolerance (0.5%)
+    uint256 public constant MIN_ORACLE_TOLERANCE_BPS = 50;
+
     /// @notice Deposit fee in basis points
     uint256 public depositFeeBps;
 
@@ -100,6 +106,9 @@ contract StakedUSDat is
 
     /// @notice Maximum rewards per transfer in basis points of totalAssets. Used to validate transferInRewards
     uint256 public maxRewardsBps;
+
+    /// @notice Tight tolerance for oracle vs execution price check, in basis points
+    uint256 public oraclePriceTolerance;
 
     modifier notZero(uint256 amount) {
         _notZero(amount);
@@ -153,6 +162,7 @@ contract StakedUSDat is
         feeRecipient = depositFeeRecipient;
         toleranceBps = 2000;
         maxRewardsBps = 250; // 2.5% of totalAssets
+        oraclePriceTolerance = 500; // 5%
     }
 
     /// @dev Authorizes an upgrade to a new implementation. Only callable by DEFAULT_ADMIN_ROLE.
@@ -317,21 +327,34 @@ contract StakedUSDat is
         IERC20(token).safeTransfer(to, amount);
     }
 
-    /// @dev Checks if a value is within ±toleranceBps of an expected value.
-    function _isWithinTolerance(uint256 value, uint256 expected) internal view returns (bool) {
-        uint256 minExpected = Math.mulDiv(expected, BPS_DENOMINATOR - toleranceBps, BPS_DENOMINATOR);
-        uint256 maxExpected = Math.mulDiv(expected, BPS_DENOMINATOR + toleranceBps, BPS_DENOMINATOR);
+    /// @dev Checks if a value is within ±bps of an expected value.
+    function _isWithinBps(uint256 value, uint256 expected, uint256 bps) internal pure returns (bool) {
+        uint256 minExpected = Math.mulDiv(expected, BPS_DENOMINATOR - bps, BPS_DENOMINATOR);
+        uint256 maxExpected = Math.mulDiv(expected, BPS_DENOMINATOR + bps, BPS_DENOMINATOR);
         return value >= minExpected && value <= maxExpected;
     }
 
-    /// @dev Validates that strcAmount matches usdatAmount / strcPurchasePrice within tolerance.
+    /// @dev Checks if a value is within ±toleranceBps of an expected value.
+    function _isWithinTolerance(uint256 value, uint256 expected) internal view returns (bool) {
+        return _isWithinBps(value, expected, toleranceBps);
+    }
+
+    /// @dev Validates that strcAmount and strcPurchasePrice are consistent with usdatAmount and the oracle price.
     function _validateConversion(uint256 usdatAmount, uint256 strcAmount, uint256 strcPurchasePrice) internal view {
         (uint256 oraclePrice, uint8 priceDecimals) = STRC_ORACLE.getPrice();
 
+        // Execution price must be close to oracle (tight oracle-specific tolerance)
+        require(_isWithinBps(strcPurchasePrice, oraclePrice, oraclePriceTolerance), OraclePriceMismatch());
+
+        // Quantity must be internally consistent with the reported execution price
         uint256 expectedStrc = Math.mulDiv(usdatAmount, 10 ** priceDecimals, strcPurchasePrice);
         require(_isWithinTolerance(strcAmount, expectedStrc), ExecutionPriceMismatch());
 
-        require(_isWithinTolerance(strcPurchasePrice, oraclePrice), OraclePriceMismatch());
+        // Oracle-anchored NAV cross-check: STRC received valued at oracle must approximate USDat exchanged.
+        // Mirrors the expectedShareValue check in WithdrawalQueueERC721.processRequests and prevents
+        // a self-referential bypass where a consistently wrong strcPurchasePrice passes both checks above.
+        uint256 strcValueAtOracle = Math.mulDiv(strcAmount, oraclePrice, 10 ** priceDecimals);
+        require(_isWithinTolerance(strcValueAtOracle, usdatAmount), ExecutionPriceMismatch());
     }
 
     /// @inheritdoc IStakedUSDat
@@ -349,7 +372,7 @@ contract StakedUSDat is
 
         IERC20(asset()).safeTransfer(msg.sender, usdatAmount);
 
-        emit Converted(usdatAmount, strcAmount);
+        emit ConvertedToStrc(usdatAmount, strcAmount);
     }
 
     /// @inheritdoc IStakedUSDat
@@ -369,7 +392,7 @@ contract StakedUSDat is
 
         IERC20(asset()).safeTransferFrom(msg.sender, address(this), usdatAmount);
 
-        emit Converted(usdatAmount, strcAmount);
+        emit ConvertedFromStrc(strcAmount, usdatAmount);
     }
 
     /// @inheritdoc IStakedUSDat
@@ -627,6 +650,18 @@ contract StakedUSDat is
         maxRewardsBps = newMaxBps;
 
         emit MaxRewardsBpsUpdated(newMaxBps);
+    }
+
+    /// @inheritdoc IStakedUSDat
+    function setOraclePriceTolerance(uint256 newTolerance) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(
+            newTolerance >= MIN_ORACLE_TOLERANCE_BPS && newTolerance <= MAX_ORACLE_TOLERANCE_BPS,
+            InvalidFee()
+        );
+
+        oraclePriceTolerance = newTolerance;
+
+        emit OraclePriceToleranceUpdated(newTolerance);
     }
 
     /// @inheritdoc IStakedUSDat

--- a/src/interfaces/IStakedUSDat.sol
+++ b/src/interfaces/IStakedUSDat.sol
@@ -111,11 +111,18 @@ interface IStakedUSDat is IERC4626 {
     event UnBlacklisted(address indexed target);
 
     /**
-     * @dev Emitted when USDat is converted to/from tSTRC.
-     * @param usdatAmount The amount of USDat involved in the conversion.
-     * @param strcAmount The amount of tSTRC involved in the conversion.
+     * @dev Emitted when USDat is converted to STRC (vault purchases STRC off-chain).
+     * @param usdatAmount The amount of USDat that left the vault.
+     * @param strcAmount The amount of STRC credited to strcBalance.
      */
-    event Converted(uint256 usdatAmount, uint256 strcAmount);
+    event ConvertedToStrc(uint256 usdatAmount, uint256 strcAmount);
+
+    /**
+     * @dev Emitted when STRC is converted back to USDat (vault sells STRC off-chain).
+     * @param strcAmount The amount of STRC debited from strcBalance.
+     * @param usdatAmount The amount of USDat returned to the vault.
+     */
+    event ConvertedFromStrc(uint256 strcAmount, uint256 usdatAmount);
 
     /**
      * @dev Emitted when rewards are transferred into the contract.
@@ -161,6 +168,12 @@ interface IStakedUSDat is IERC4626 {
      * @param newMaxBps The new max rewards in basis points.
      */
     event MaxRewardsBpsUpdated(uint256 newMaxBps);
+
+    /**
+     * @dev Emitted when the oracle price tolerance is updated.
+     * @param newTolerance The new oracle price tolerance in basis points.
+     */
+    event OraclePriceToleranceUpdated(uint256 newTolerance);
 
     // ============ Blacklist Functions ============
 
@@ -462,7 +475,7 @@ interface IStakedUSDat is IERC4626 {
 
     /**
      * @notice Updates the vesting period for reward distributions.
-     * @dev Only callable by addresses with the PROCESSOR_ROLE.
+     * @dev Only callable by addresses with the DEFAULT_ADMIN_ROLE.
      * Cannot be changed while rewards are still vesting.
      * @param newVestingPeriod The new vesting period in seconds (must be <= MAX_VESTING_PERIOD).
      */
@@ -470,7 +483,7 @@ interface IStakedUSDat is IERC4626 {
 
     /**
      * @notice Updates the deposit fee.
-     * @dev Only callable by addresses with the PROCESSOR_ROLE.
+     * @dev Only callable by addresses with the DEFAULT_ADMIN_ROLE.
      * Can be set to 0 to disable fees.
      * @param newFeeBps The new fee in basis points (must be <= MAX_DEPOSIT_FEE_BPS).
      */
@@ -478,7 +491,7 @@ interface IStakedUSDat is IERC4626 {
 
     /**
      * @notice Updates the fee recipient address.
-     * @dev Only callable by addresses with the PROCESSOR_ROLE.
+     * @dev Only callable by addresses with the DEFAULT_ADMIN_ROLE.
      * Can be set to address(0) to disable fees.
      * @param newRecipient The new fee recipient address.
      */
@@ -498,6 +511,22 @@ interface IStakedUSDat is IERC4626 {
      * @param newMaxBps The new maximum in basis points (e.g., 250 = 2.5%).
      */
     function setMaxRewardsBps(uint256 newMaxBps) external;
+
+    /**
+     * @notice Updates the oracle price tolerance used in conversion validation.
+     * @dev Only callable by addresses with the DEFAULT_ADMIN_ROLE.
+     * Separate from executionTolerance (toleranceBps) — this governs how far the
+     * processor-reported execution price may deviate from the Chainlink oracle price.
+     * Tighter than toleranceBps; raise only in black-swan market conditions.
+     * @param newTolerance The new tolerance in basis points (MIN_ORACLE_TOLERANCE_BPS to MAX_ORACLE_TOLERANCE_BPS).
+     */
+    function setOraclePriceTolerance(uint256 newTolerance) external;
+
+    /**
+     * @notice Returns the current oracle price tolerance in basis points.
+     * @return The oracle price tolerance value.
+     */
+    function oraclePriceTolerance() external view returns (uint256);
 
     /**
      * @notice Pauses the contract.


### PR DESCRIPTION
Replace the default Foundry boilerplate README with proper documentation.

## Changes
- Protocol overview with on-chain vs off-chain (Saturn Fund Ltd) split
- Mermaid flowchart for deposit → yield rotation → redemption flow
- Mermaid state diagram for withdrawal queue lifecycle (Requested → InProgress → Processed → Claimed, including unlockRequests path)
- Key parameter tables for StakedUSDat and StrcPriceOracle (all values verified against source)
- Role tables for StakedUSDat and WithdrawalQueueERC721
- Deployed addresses (mainnet + Sepolia), deployment and upgrade instructions