### PR TITLE
L-05: return true for IWithdrawalQueueERC721

### DIFF
--- a/docs/saturn-v2-spec.md
+++ b/docs/saturn-v2-spec.md
@@ -62,6 +62,8 @@ sUSDat mutations; queue-local pause separately gates queue-only actions (§2.6).
 Retained with narrower surfaces: request creation and share escrow, single-request reads,
 current-owner request enumeration, NFT ownership, and pause. Cancellation, compliance, and
 roles change per §2.6–2.8.
+ERC-165 advertises `IWithdrawalQueueERC721` in addition to the inherited ERC-721,
+ERC-721 metadata/enumeration, and AccessControl interfaces.
 
 ### Removed functions
 

--- a/src/v2/WithdrawalQueueERC721.sol
+++ b/src/v2/WithdrawalQueueERC721.sol
@@ -341,13 +341,13 @@ contract WithdrawalQueueERC721 is
         return super._update(to, tokenId, auth);
     }
 
-    /// @dev Override required by Solidity for multiple inheritance.
+    /// @dev Advertises the protocol interface in addition to inherited ERC-165 support.
     function supportsInterface(bytes4 interfaceId)
         public
         view
         override(ERC721EnumerableUpgradeable, AccessControlUpgradeable)
         returns (bool)
     {
-        return super.supportsInterface(interfaceId);
+        return interfaceId == type(IWithdrawalQueueERC721).interfaceId || super.supportsInterface(interfaceId);
     }
 }

--- a/test/v2/withdrawal/WithdrawalQueueLifecycle.t.sol
+++ b/test/v2/withdrawal/WithdrawalQueueLifecycle.t.sol
@@ -2,8 +2,13 @@
 pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {IERC721Enumerable} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
+import {IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import {WithdrawalQueueERC721} from "../../../src/v2/WithdrawalQueueERC721.sol";
 import {IWithdrawalQueueERC721} from "../../../src/v2/interfaces/IWithdrawalQueueERC721.sol";
@@ -144,6 +149,18 @@ contract WithdrawalQueueLifecycleTest is Test {
         queue = WithdrawalQueueERC721(address(proxy));
         queue.initializeV2(address(this), address(this), address(this), address(this));
         stakedUsdat.setRecoveryAddress(bob);
+    }
+
+    function test_supportsInterface_AdvertisesQueueAndInheritedInterfaces() public view {
+        bytes4 queueInterfaceId = type(IWithdrawalQueueERC721).interfaceId;
+        assertEq(queueInterfaceId, bytes4(0xcf58cc7c));
+        assertTrue(queue.supportsInterface(queueInterfaceId));
+        assertTrue(queue.supportsInterface(type(IERC165).interfaceId));
+        assertTrue(queue.supportsInterface(type(IERC721).interfaceId));
+        assertTrue(queue.supportsInterface(type(IERC721Metadata).interfaceId));
+        assertTrue(queue.supportsInterface(type(IERC721Enumerable).interfaceId));
+        assertTrue(queue.supportsInterface(type(IAccessControl).interfaceId));
+        assertFalse(queue.supportsInterface(0xffffffff));
     }
 
     function test_addRequest_RejectsRestrictedUserByEitherToken() public {


### PR DESCRIPTION
Implemented L-05.

  src/v2/WithdrawalQueueERC721.sol:351 now returns true for IWithdrawalQueueERC721 while
  retaining inherited ERC-165 support:

  return interfaceId == type(IWithdrawalQueueERC721).interfaceId
      || super.supportsInterface(interfaceId);
