### PR TITLE
L-01: Document the intentional EIP-4626 deviation

### DIFF
--- a/docs/saturn-v2-spec.md
+++ b/docs/saturn-v2-spec.md
@@ -33,7 +33,7 @@ the sole token-backed tradable module.
 | `transferInRewards` + STRC vesting surface | moves into STRCMirrorModule (§2.3); retires with it |
 | `burnQueuedShares(shares, strcAmount)` | `redeemQueuedShares(shares, minSharePrice)` (§2.6) |
 | `collectDust` | dropped — per-request settlement leaves no dust |
-| oracle failure reverts `totalAssets()` and all views | same fail-closed reverts, kept deliberately; `maxDeposit`/`maxMint` catch and report 0 for ERC-4626 (§2.2) |
+| oracle failure reverts `totalAssets()` and pricing-dependent views | same fail-closed reverts, kept deliberately as an EIP-4626 deviation; `maxDeposit`/`maxMint` catch and report 0 (§2.2) |
 | — | `transferInSurplus` cash surplus inlet (§2.1) |
 | one configured deposit fee | market-mode fee: zero in Regular, elevated in Elevated, and deposits disabled in Restricted (§2.4, §2.7) |
 | — | `MarketMode` selects Regular, Elevated, or Restricted operation; Regular authorization expires fail-safe to Elevated, and hard pause remains separate (§2.7) |
@@ -258,13 +258,16 @@ changes only the oracle used by `recognizedValue()` and `getPrice()`, not the mo
 vault, or recognized balance. The public typed state variable provides the canonical
 `oracle()` getter; there is no redundant `getOracle()` function.
 
-**Failure semantics — fail closed.** If a module cannot price, `recognizedValue()` reverts
-through `totalAssets()`, halting every value-sensitive path, including mints, queue
-processing, rotations, and downstream `convertToAssets`/`previewRedeem` use. Nonpricing
+**Failure semantics — fail closed; intentional EIP-4626 deviation.** If a module cannot
+price, `recognizedValue()` reverts through `totalAssets()`, halting every value-sensitive
+path, including mints, queue processing, rotations, and the pricing-dependent
+`convertToAssets`, `convertToShares`, and `preview*` views. EIP-4626 requires
+`totalAssets()` and its conversion surface not to revert, so this propagation is an
+intentional deviation from the standard. Integrators must catch these reverts and treat NAV
+as unavailable, not as zero or as authorization to use a cached price. Nonpricing
 operations—share transfers, `requestRedeem`, `updateMinSharePrice`, `claim`, and
-seizures—remain live. For ERC-4626 compliance, `maxDeposit`/`maxMint` catch
-`totalAssets()` failure and return 0; `max*` functions must not revert. Manual vault pause
-follows the STRCon impairment path in Appendix G.
+seizures—remain live. `maxDeposit` and `maxMint` alone normalize a pricing failure to 0.
+Manual vault pause follows the STRCon impairment path in Appendix G.
 
 **Rescue.** `rescueTokens(token, amount)` (`ENFORCER_ROLE`) sends only untracked
 excess to the current `recoveryAddress`; it accepts no caller-selected destination.
@@ -412,7 +415,16 @@ rejects feeds not reporting 8 decimals. Replacing either feed requires a new wra
 `STRConModule.setOracle(newOracle)`, which independently rejects a wrapper unless its
 `decimals()` value is 8. Numeric setters use
 `onlyVaultRole(PARAMETER_MANAGER_ROLE)` against immutable `VAULT` and emit configuration
-events. STRCMirrorModule keeps the deployed v1 `StrcPriceOracle`.
+events. Oracle rotation remains callable while the vault is paused or the current wrapper
+cannot price because it does not require a successful read from the current wrapper.
+STRCMirrorModule keeps the deployed v1 `StrcPriceOracle`.
+
+There is no standby STRCon replacement price source or backup wrapper at launch. A permanent
+failure or deprecation of the configured source requires Saturn to work with Chainlink to
+establish a replacement source, deploy and review a compatible wrapper, and execute the
+timelocked `setOracle` rotation. The contract therefore provides a recovery mechanism but
+does not guarantee a bounded recovery time. Until a working source is available—or
+governance executes a timelocked recovery upgrade—the vault remains fail closed.
 
 #### STRCon operations
 

--- a/test/v2/vault/StakedUSDatFixedModuleAccounting.t.sol
+++ b/test/v2/vault/StakedUSDatFixedModuleAccounting.t.sol
@@ -14,7 +14,9 @@ import {IAccountingModule} from "../../../src/v2/interfaces/modules/IAccountingM
 import {IStakedUSDat} from "../../../src/v2/interfaces/IStakedUSDat.sol";
 import {ISTRConModule} from "../../../src/v2/interfaces/modules/ISTRConModule.sol";
 import {ITradableModule} from "../../../src/v2/interfaces/modules/ITradableModule.sol";
+import {ISTRConPriceOracle} from "../../../src/v2/interfaces/oracles/ISTRConPriceOracle.sol";
 import {IWithdrawalQueueERC721} from "../../../src/v2/interfaces/IWithdrawalQueueERC721.sol";
+import {STRConModule} from "../../../src/v2/modules/STRCon/STRConModule.sol";
 import {BoundMirrorModuleMock, V2InitializationHelper} from "../helpers/V2InitializationHelper.sol";
 
 contract FixedModuleUSDatMock is ERC20 {
@@ -110,6 +112,30 @@ contract FixedTradableModuleMock is ITradableModule {
     function sell(uint256) external pure {}
 }
 
+contract FixedModulePriceOracleMock is ISTRConPriceOracle {
+    error PricingFailed();
+
+    uint256 private immutable _PRICE;
+    bool private _pricingFails;
+
+    constructor(uint256 price_) {
+        _PRICE = price_;
+    }
+
+    function setPricingFails(bool pricingFails) external {
+        _pricingFails = pricingFails;
+    }
+
+    function decimals() external pure returns (uint8) {
+        return 8;
+    }
+
+    function getPrice() external view returns (uint256) {
+        if (_pricingFails) revert PricingFailed();
+        return _PRICE;
+    }
+}
+
 contract StakedUSDatFixedModuleAccountingTest is Test {
     uint256 private constant CASH = 37_000_003;
     uint256 private constant MIRROR_VALUE = 11_000_007;
@@ -199,6 +225,34 @@ contract StakedUSDatFixedModuleAccountingTest is Test {
 
         vm.expectRevert(FixedTradableModuleMock.PricingFailed.selector);
         vault.totalAssets();
+    }
+
+    function test_totalAssets_RecoversAfterOracleRotationWhilePaused() public {
+        StakedUSDat recoveryVault = _deployVault();
+        FixedAccountingModuleMock recoveryMirror = new FixedAccountingModuleMock(address(recoveryVault));
+        FixedModulePriceOracleMock failedOracle = new FixedModulePriceOracleMock(100e8);
+        STRConModule recoveryModule = new STRConModule(address(recoveryVault), address(usdat), failedOracle);
+        _initializeV2(recoveryVault, recoveryMirror, recoveryModule);
+
+        vm.prank(address(recoveryVault));
+        recoveryModule.buy(1e18);
+        failedOracle.setPricingFails(true);
+
+        vm.expectRevert(FixedModulePriceOracleMock.PricingFailed.selector);
+        recoveryVault.totalAssets();
+        assertEq(recoveryVault.maxDeposit(address(this)), 0);
+        assertEq(recoveryVault.maxMint(address(this)), 0);
+
+        recoveryVault.pause();
+        FixedModulePriceOracleMock replacementOracle = new FixedModulePriceOracleMock(102e8);
+        recoveryModule.setOracle(address(replacementOracle));
+
+        assertEq(recoveryModule.balance(), 1e18);
+        assertEq(recoveryVault.totalAssets(), 102e6);
+
+        recoveryVault.unpause();
+        assertEq(recoveryVault.maxDeposit(address(this)), type(uint256).max);
+        assertEq(recoveryVault.maxMint(address(this)), type(uint256).max);
     }
 
     function test_maxDepositAndMaxMint_ReturnMaximumWhenPricingIsHealthy() public {


### PR DESCRIPTION
  - Updated docs/saturn-v2-spec.md:261 to document the intentional EIP-4626
    (https://eips.ethereum.org/EIPS/eip-4626) deviation and integrator behavior.

  - Documented that no backup source currently exists, Chainlink coordination is required, and
    recovery time is unbounded.

  - Added an oracle-failure-to-recovery test in test/v2/vault/
    StakedUSDatFixedModuleAccounting.t.sol:230.